### PR TITLE
Remove `os` and `typing` dependencies

### DIFF
--- a/babylab/api.py
+++ b/babylab/api.py
@@ -10,9 +10,7 @@ from datetime import datetime
 from functools import lru_cache, singledispatch
 from json import dump, dumps, loads
 from os import environ, getenv, walk
-from os.path import join
 from pathlib import Path
-from typing import Sequence
 from warnings import warn
 from zipfile import ZIP_DEFLATED, ZipFile
 
@@ -120,12 +118,12 @@ def get_api_key(path: Path | str | None = None, name: str = "API_KEY") -> str:
     return token
 
 
-def post_request(fields: dict, timeout: Sequence[int] = (5, 10)) -> requests.Response:
+def post_request(fields: dict, timeout: tuple[int, int] = (5, 10)) -> requests.Response:
     """Make a POST request to the REDCap database.
 
     Args:
         fields (dict): Fields to retrieve.
-        timeout (Sequence[int], optional): Timeout of HTTP request in seconds. Defaults to 10.
+        timeout (tuple[int, int], optional): Timeout of HTTP request in seconds. Defaults to 10.
 
     Raises:
         requests.exceptions.HTTPError: If HTTP request fails.
@@ -733,7 +731,7 @@ def redcap_backup(path: Path | str = Path("tmp")) -> Path:
     for root, _, files in walk(str(path), topdown=False):
         with ZipFile(file, "w", ZIP_DEFLATED) as z:
             for f in files:
-                z.write(join(root, f))
+                z.write(Path(root, f))
 
     return file
 

--- a/babylab/utils.py
+++ b/babylab/utils.py
@@ -2,7 +2,6 @@
 Util functions for the app.
 """
 
-from collections.abc import Sequence
 from copy import deepcopy
 from datetime import date, datetime, timedelta
 from typing import Generator, Iterator
@@ -14,14 +13,14 @@ from babylab.globals import COLNAMES
 
 
 def is_in_data_dict(
-    variable: str, data_dict: dict, x: Sequence[str] | str | None = None
+    variable: str, data_dict: dict, x: list[str] | str | None = None
 ) -> list[str]:
     """Check that a value is an element in the data dictionary.
 
     Args:
         variable (str): Key in which to look for.
         data_dict (dict): Dictionary to check.
-        x (Sequence[str] | str | None, optional): Value to look up in the data dictionary. Defaults to None (all options are checked for the variable).
+        x (list[str] | str | None, optional): Value to look up in the data dictionary. Defaults to None (all options are checked for the variable).
 
     Raises:
         ValueError: If `x` is not an option present in `data_dict`.
@@ -238,8 +237,8 @@ def get_week_n(timestamp: date) -> int:
 
 def get_weekly_apts(
     records: api.Records,
-    study: Sequence | str | None = None,
-    status: Sequence | str | None = None,
+    study: list[str] | str | None = None,
+    status: list[str] | str | None = None,
 ) -> int:
     """Get weekly number of appointments.
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,14 +1,14 @@
 """Test API."""
 
-import os
 from datetime import datetime
+from os import getenv
 
 import pytest
 
 from babylab import api
 from tests import conftest
 
-IS_GIHTUB_ACTIONS = os.getenv("GITHUB_ACTIONS") == "true"
+IS_GIHTUB_ACTIONS = getenv("GITHUB_ACTIONS") == "true"
 
 
 class TestApiKey:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@
 
 from datetime import date, datetime
 from random import choice, sample
-from typing import Generator, Sequence
+from typing import Generator
 
 import polars as pl
 from pytest import raises
@@ -109,7 +109,7 @@ class TestGetParticipantTable:
         assert isinstance(df, pl.DataFrame)
 
     def test_get_apt_table_id_list(
-        self, apt_id: str | Sequence[str] | None = None, k: int = 100
+        self, apt_id: str | list[str] | None = None, k: int = 100
     ):
         if apt_id is None:
             apt_id = list(conftest.RECORDS.appointments.records.keys())


### PR DESCRIPTION
Removes `Sequence` for lists and tuples, and `os.path.join` for `pathlib` methods. 